### PR TITLE
Release `1.27.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 * [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
 * [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
 * [`mattoid/flarum-ext-store-invite`](https://github.com/Mattoids/flarum-ext-store-invite)
+* [`neoncube/flarum-private-messages`](https://github.com/neoncube2/flarum-private-messages)
 * [`nodeloc/flarum-ext-referral`](https://github.com/nodeloc/flarum-ext-referral)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 
 * [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
 * [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
+* [`mattoid/flarum-ext-store-invite`](https://github.com/Mattoids/flarum-ext-store-invite)
 * [`nodeloc/flarum-ext-referral`](https://github.com/nodeloc/flarum-ext-referral)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 
-1.27.0 (XXXX-XX-XX)
+1.27.0 (2025-04-19)
 -------------------
 
 **Menambahkan dukungan untuk ekstensi**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
 
 **Terjemahan terbaru untuk ekstensi**:
 
+* [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
+* [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
 * [`nodeloc/flarum-ext-referral`](https://github.com/nodeloc/flarum-ext-referral)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@ CHANGELOG
 =========
 
 
+1.27.0 (XXXX-XX-XX)
+-------------------
+
+**Menambahkan dukungan untuk ekstensi**:
+
+* [`kk14569/flarum-anti-gmail-alias`](https://github.com/kk14569/flarum-anti-gmail-alias)
+
+
+**Terjemahan terbaru untuk ekstensi**:
+
+* [`nodeloc/flarum-ext-referral`](https://github.com/nodeloc/flarum-ext-referral)
+
+
+Semua perubahan: [1.26.0...1.27.0](https://github.com/flarum-lang/indonesian/compare/1.26.0...1.27.0).
+
+
 1.26.0 (2025-03-11)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 * [`fof/links`](https://github.com/FriendsOfFlarum/links)
 * [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
 * [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
+* [`ianm/twofactor`](https://github.com/imorland/flarum-ext-twofactor)
 * [`mattoid/flarum-ext-store-invite`](https://github.com/Mattoids/flarum-ext-store-invite)
 * [`neoncube/flarum-private-messages`](https://github.com/neoncube2/flarum-private-messages)
 * [`nodeloc/flarum-ext-referral`](https://github.com/nodeloc/flarum-ext-referral)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 
 **Menambahkan dukungan untuk ekstensi**:
 
+* [`fof/horizon`](https://github.com/FriendsOfFlarum/horizon)
 * [`kk14569/flarum-anti-gmail-alias`](https://github.com/kk14569/flarum-anti-gmail-alias)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 * [`fof/doorman`](https://github.com/FriendsOfFlarum/doorman)
 * [`fof/links`](https://github.com/FriendsOfFlarum/links)
 * [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
+* [`fof/socialprofile`](https://github.com/FriendsOfFlarum/socialprofile)
 * [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
 * [`ianm/twofactor`](https://github.com/imorland/flarum-ext-twofactor)
 * [`mattoid/flarum-ext-store-invite`](https://github.com/Mattoids/flarum-ext-store-invite)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 
 **Terjemahan terbaru untuk ekstensi**:
 
+* [`fof/links`](https://github.com/FriendsOfFlarum/links)
 * [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
 * [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
 * [`mattoid/flarum-ext-store-invite`](https://github.com/Mattoids/flarum-ext-store-invite)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 
 **Terjemahan terbaru untuk ekstensi**:
 
+* [`fof/doorman`](https://github.com/FriendsOfFlarum/doorman)
 * [`fof/links`](https://github.com/FriendsOfFlarum/links)
 * [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
 * [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 * [`fof/doorman`](https://github.com/FriendsOfFlarum/doorman)
 * [`fof/links`](https://github.com/FriendsOfFlarum/links)
 * [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
+* [`fof/oauth`](https://github.com/FriendsOfFlarum/oauth)
 * [`fof/socialprofile`](https://github.com/FriendsOfFlarum/socialprofile)
 * [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
 * [`ianm/twofactor`](https://github.com/imorland/flarum-ext-twofactor)


### PR DESCRIPTION
This is a draft of changelog for the `1.27.0` release.
Here you can find all related translations changes: [1.26.0...master](https://github.com/flarum-lang/indonesian/compare/1.26.0...master).

> ### ⚠️ Do not merge this pull request manually ⚠️
> 
> You should **[approve](https://github.com/rob006-software/flarum-translations/wiki/How-to-approve-release-pull-request)** this pull request instead. After approving, I will automatically update it (release date needs to be adjusted), merge, and tag a new release. You can read more about the process on [forum](https://discuss.flarum.org/d/20807-simplify-translation-process-with-weblate/76).

<details>
<summary>Show release notes preview</summary>

## 1.27.0

<!-- release-notes-begin -->
**Menambahkan dukungan untuk ekstensi**:

* [`fof/horizon`](https://github.com/FriendsOfFlarum/horizon)
* [`kk14569/flarum-anti-gmail-alias`](https://github.com/kk14569/flarum-anti-gmail-alias)


**Terjemahan terbaru untuk ekstensi**:

* [`fof/doorman`](https://github.com/FriendsOfFlarum/doorman)
* [`fof/links`](https://github.com/FriendsOfFlarum/links)
* [`fof/masquerade`](https://github.com/FriendsOfFlarum/masquerade)
* [`fof/oauth`](https://github.com/FriendsOfFlarum/oauth)
* [`fof/socialprofile`](https://github.com/FriendsOfFlarum/socialprofile)
* [`huseyinfiliz/notificationhub`](https://github.com/huseyinfiliz/notificationhub)
* [`ianm/twofactor`](https://github.com/imorland/flarum-ext-twofactor)
* [`mattoid/flarum-ext-store-invite`](https://github.com/Mattoids/flarum-ext-store-invite)
* [`neoncube/flarum-private-messages`](https://github.com/neoncube2/flarum-private-messages)
* [`nodeloc/flarum-ext-referral`](https://github.com/nodeloc/flarum-ext-referral)


Semua perubahan: [1.26.0...1.27.0](https://github.com/flarum-lang/indonesian/compare/1.26.0...1.27.0).



<!-- release-notes-end -->

</details>